### PR TITLE
Allow a zero sized dimension extent

### DIFF
--- a/src/brush.js
+++ b/src/brush.js
@@ -112,7 +112,7 @@ function local(node) {
 
 function empty(extent) {
   return extent[0][0] === extent[1][0]
-      || extent[0][1] === extent[1][1];
+      && extent[0][1] === extent[1][1];
 }
 
 export function brushSelection(node) {


### PR DESCRIPTION
The current implementation marks an extent of `[[100,0], [200,0]]` as empty. A selection like this occurs when the user makes a 'perfect drag' over a single axis. Depending on the implementation of the brush interaction this could be still a valid extent, in my case it is valid.