### PR TITLE
Only orphan mouse gestures.

### DIFF
--- a/src/brush.js
+++ b/src/brush.js
@@ -288,14 +288,16 @@ function brush(dim) {
   }
 
   function emitter(that, args, clean) {
-    return (!clean && that.__brush.emitter) || new Emitter(that, args);
+    var emit = that.__brush.emitter;
+    return emit && (!clean || !emit.clean) ? emit : new Emitter(that, args, clean);
   }
 
-  function Emitter(that, args) {
+  function Emitter(that, args, clean) {
     this.that = that;
     this.args = args;
     this.state = that.__brush;
     this.active = 0;
+    this.clean = clean;
   }
 
   Emitter.prototype = {


### PR DESCRIPTION
This avoids orphaning a programmatic brush transition.

Related #18.