### PR TITLE
Pass along mode to BrushEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,4 @@ When a [brush event listener](#brush_on) is invoked, it receives the current bru
 * `type` - the string “start”, “brush” or “end”; see [*brush*.on](#brush_on).
 * `selection` - the current [brush selection](#brushSelection).
 * `sourceEvent` - the underlying input event, such as mousemove or touchmove.
+* `mode` - the string “drag”, “space”, “handle” or “center”; the mode of the brush.

--- a/src/brush.js
+++ b/src/brush.js
@@ -231,7 +231,7 @@ function brush(dim) {
             function tween(t) {
               state.selection = t === 1 && selection1 === null ? null : i(t);
               redraw.call(that);
-              emit.brush();
+              emit.brush(mode);
             }
 
             return selection0 !== null && selection1 !== null ? tween : tween(1);
@@ -248,7 +248,7 @@ function brush(dim) {
             interrupt(that);
             state.selection = selection1 === null ? null : selection1;
             redraw.call(that);
-            emit.start().brush().end();
+            emit.start(mode).brush(mode).end(mode);
           });
     }
   };
@@ -305,21 +305,21 @@ function brush(dim) {
       if (++this.active === 1) this.state.emitter = this, this.starting = true;
       return this;
     },
-    start: function() {
-      if (this.starting) this.starting = false, this.emit("start");
-      else this.emit("brush");
+    start: function(mode) {
+      if (this.starting) this.starting = false, this.emit("start", mode);
+      else this.emit("brush", mode);
       return this;
     },
-    brush: function() {
-      this.emit("brush");
+    brush: function(mode) {
+      this.emit("brush", mode);
       return this;
     },
-    end: function() {
-      if (--this.active === 0) delete this.state.emitter, this.emit("end");
+    end: function(mode) {
+      if (--this.active === 0) delete this.state.emitter, this.emit("end", mode);
       return this;
     },
-    emit: function(type) {
-      customEvent(new BrushEvent(brush, type, dim.output(this.state.selection)), listeners.apply, listeners, [type, this.that, this.args]);
+    emit: function(type, mode) {
+      customEvent(new BrushEvent(brush, type, dim.output(this.state.selection), mode), listeners.apply, listeners, [type, this.that, this.args]);
     }
   };
 
@@ -391,7 +391,7 @@ function brush(dim) {
     nopropagation();
     interrupt(that);
     redraw.call(that);
-    emit.start();
+    emit.start(mode);
 
     function moved() {
       var point1 = pointer(that);
@@ -456,7 +456,7 @@ function brush(dim) {
           || selection[1][1] !== s1) {
         state.selection = [[w1, n1], [e1, s1]];
         redraw.call(that);
-        emit.brush();
+        emit.brush(mode);
       }
     }
 
@@ -474,7 +474,7 @@ function brush(dim) {
       overlay.attr("cursor", cursors.overlay);
       if (state.selection) selection = state.selection; // May be set by brush.move (on start)!
       if (empty(selection)) state.selection = null, redraw.call(that);
-      emit.end();
+      emit.end(mode);
     }
 
     function keydowned() {

--- a/src/brush.js
+++ b/src/brush.js
@@ -408,7 +408,7 @@ function brush(dim) {
     }
 
     redraw.call(that);
-    emit.start(undefined, mode.name);
+    emit.start(event, mode.name);
 
     function moved(event) {
       for (const p of event.changedTouches || [event]) {

--- a/src/brush.js
+++ b/src/brush.js
@@ -391,7 +391,7 @@ function brush(dim) {
     nopropagation();
     interrupt(that);
     redraw.call(that);
-    emit.start(mode);
+    emit.start(mode.name);
 
     function moved() {
       var point1 = pointer(that);
@@ -456,7 +456,7 @@ function brush(dim) {
           || selection[1][1] !== s1) {
         state.selection = [[w1, n1], [e1, s1]];
         redraw.call(that);
-        emit.brush(mode);
+        emit.brush(mode.name);
       }
     }
 
@@ -474,7 +474,7 @@ function brush(dim) {
       overlay.attr("cursor", cursors.overlay);
       if (state.selection) selection = state.selection; // May be set by brush.move (on start)!
       if (empty(selection)) state.selection = null, redraw.call(that);
-      emit.end(mode);
+      emit.end(mode.name);
     }
 
     function keydowned() {

--- a/src/brush.js
+++ b/src/brush.js
@@ -323,7 +323,7 @@ function brush(dim) {
           sourceEvent: event,
           target: brush,
           selection: dim.output(this.state.selection),
-          mode: mode,
+          mode,
           dispatch: listeners
         }),
         d

--- a/src/brush.js
+++ b/src/brush.js
@@ -231,7 +231,7 @@ function brush(dim) {
             function tween(t) {
               state.selection = t === 1 && selection1 === null ? null : i(t);
               redraw.call(that);
-              emit.brush(mode);
+              emit.brush();
             }
 
             return selection0 !== null && selection1 !== null ? tween : tween(1);
@@ -248,7 +248,7 @@ function brush(dim) {
             interrupt(that);
             state.selection = selection1 === null ? null : selection1;
             redraw.call(that);
-            emit.start(mode).brush(mode).end(mode);
+            emit.start().brush().end();
           });
     }
   };

--- a/src/event.js
+++ b/src/event.js
@@ -1,5 +1,6 @@
-export default function(target, type, selection) {
+export default function(target, type, selection, mode) {
   this.target = target;
   this.type = type;
   this.selection = selection;
+  this.mode = mode;
 }

--- a/src/event.js
+++ b/src/event.js
@@ -10,7 +10,7 @@ export default function BrushEvent(type, {
     sourceEvent: {value: sourceEvent, enumerable: true, configurable: true},
     target: {value: target, enumerable: true, configurable: true},
     selection: {value: selection, enumerable: true, configurable: true},
-    mode: {value: mode, enenumerable: true, configurable: true},
+    mode: {value: mode, enumerable: true, configurable: true},
     _: {value: dispatch}
   });
 }


### PR DESCRIPTION
Hello.

In my project I need to know the `mode` of the brush in the event handler.
This is because depending on which axis (x/y) the user is resizing the selection in, or whether the user is moving the selection without resizing (dragging), I need to change my logic on the snapping/clipping of the brush selection.

In this PR is my attempt at including the `mode` in `BrushEvent`.
I've tested it in my local project and it works fine.
Not sure if this is how you would solve it, so feel free to edit it.